### PR TITLE
Added MELDThermal to python wrapper, added conduction examples

### DIFF
--- a/examples/pyfuntofem/conduction/README
+++ b/examples/pyfuntofem/conduction/README
@@ -1,0 +1,13 @@
+There are two examples in this folder.
+
+The first is uniform_case:
+This folder contains - 
+
+two_plate_conduction.py, which handles the uniform case: two identical plates with identical meshes and different temperature boundary conditions on their opposite edges. the shared edge temperature is computed using a loop with MELDThermal. It uses left_plate.bdf and right_plate.bdf, which can be created with minor modifications to the generate_bdf scripts
+
+tacs_verification.py, which runs the same case but as one unified mesh for comparison.
+uses rect_plate.bdf, again can be created with generate_bdf scripts
+
+The second is mesh_density:
+This is essentially the same but with two different mesh densities chosen to demonstrate the nearest-neighbor matching capabilities of MELDThermal
+The verification case is the same as the one in the uniform_case folder

--- a/examples/pyfuntofem/conduction/mesh_density/generate_left_bdf.py
+++ b/examples/pyfuntofem/conduction/mesh_density/generate_left_bdf.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+nx = 101
+ny = 101
+
+x = np.linspace(0, 1.0, num = nx)
+y = np.linspace(0, 1.0, num = ny)
+
+nodes = np.arange(1, nx*ny+1, dtype=np.int).reshape(nx, ny)
+
+fp = open('left_plate.bdf', 'w')
+fp.write('$ Input file for the left plate\n')
+fp.write('SOL 103\nCEND\nBEGIN BULK\n')
+
+spclist1 = []
+spclist2 = []
+
+# Write the grid points to a file
+for j in range(ny):
+    for i in range(nx):
+        # Write the nodal data
+        spc = ' '
+        coord_disp = 0
+        coord_id = 0
+        seid = 0
+        
+        fp.write('%-8s%16d%16d%16.9e%16.9e*       \n'%
+                 ('GRID*', nodes[i, j], coord_id, 
+                  x[i], y[j]))
+        fp.write('*       %16.9e%16d%16s%16d        \n'%
+                 (0.0, coord_disp, spc, seid))
+
+        if x[i] == 0.0:
+            spclist1.append(nodes[i,j])
+
+        if x[i] == 1.0:
+            spclist2.append(nodes[i,j])
+
+# Output first order quad elements
+
+elem = 1
+part_id = 1
+for j in range(0, nodes.shape[1]-1, 1):
+    for i in range(0, nodes.shape[0]-1, 1):
+        # Write the connectivity data
+        # CQUAD9 elem id n1 n2 n3 n4 n5 n6
+        #        n7   n8 n9
+        fp.write('%-8s%8d%8d%8d%8d%8d%8d\n'%
+                 ('CQUAD4', elem, part_id, 
+                  nodes[i,   j],   nodes[i+1, j], 
+                  nodes[i+1, j+1], nodes[i,   j+1]))
+
+        elem += 1
+
+for node in spclist1:
+    spc = '123456'
+    fp.write('%-8s%8d%8d%8s%8.6f\n'%
+             ('SPC', 1, node, spc, 300.0))
+
+for node in spclist2:
+    spc = '123456'
+    fp.write('%-8s%8d%8d%8s%8.6f\n'%
+             ('SPC', 1, node, spc, 400.0))
+
+fp.write('END BULK')
+fp.close()

--- a/examples/pyfuntofem/conduction/mesh_density/generate_right_bdf.py
+++ b/examples/pyfuntofem/conduction/mesh_density/generate_right_bdf.py
@@ -1,0 +1,66 @@
+import numpy as np
+# finer mesh than left plate
+nx = 161
+ny = 161
+
+x = np.linspace(1.0, 2.0, num = nx)
+y = np.linspace(0, 1.0, num = ny)
+
+nodes = np.arange(1, nx*ny+1, dtype=np.int).reshape(nx, ny)
+
+fp = open('right_plate.bdf', 'w')
+fp.write('$ Input file for the right plate\n')
+fp.write('SOL 103\nCEND\nBEGIN BULK\n')
+
+spclist1 = []
+spclist2 = []
+
+# Write the grid points to a file
+for j in range(ny):
+    for i in range(nx):
+        # Write the nodal data
+        spc = ' '
+        coord_disp = 0
+        coord_id = 0
+        seid = 0
+        
+        fp.write('%-8s%16d%16d%16.9e%16.9e*       \n'%
+                 ('GRID*', nodes[i, j], coord_id, 
+                  x[i], y[j]))
+        fp.write('*       %16.9e%16d%16s%16d        \n'%
+                 (0.0, coord_disp, spc, seid))
+
+#        if x[i] == 0.0:
+#            spclist1.append(nodes[i,j])
+
+        if x[i] == 2.0:
+            spclist2.append(nodes[i,j])
+
+# Output first order quad elements
+
+elem = 1
+part_id = 1
+for j in range(0, nodes.shape[1]-1, 1):
+    for i in range(0, nodes.shape[0]-1, 1):
+        # Write the connectivity data
+        # CQUAD9 elem id n1 n2 n3 n4 n5 n6
+        #        n7   n8 n9
+        fp.write('%-8s%8d%8d%8d%8d%8d%8d\n'%
+                 ('CQUAD4', elem, part_id, 
+                  nodes[i,   j],   nodes[i+1, j], 
+                  nodes[i+1, j+1], nodes[i,   j+1]))
+
+        elem += 1
+
+#for node in spclist1:
+#    spc = '123456'
+#    fp.write('%-8s%8d%8d%8s%8.6f\n'%
+#             ('SPC', 1, node, spc, 300.0))
+
+for node in spclist2:
+    spc = '123456'
+    fp.write('%-8s%8d%8d%8s%8.6f\n'%
+             ('SPC', 1, node, spc, 400.0))
+
+fp.write('END BULK')
+fp.close()

--- a/examples/pyfuntofem/conduction/mesh_density/two_plate_conduction_mesh_density.py
+++ b/examples/pyfuntofem/conduction/mesh_density/two_plate_conduction_mesh_density.py
@@ -1,0 +1,227 @@
+from __future__ import print_function
+from mpi4py import MPI
+import numpy as np
+import matplotlib.pyplot as plt
+import sys
+from tacs import TACS, elements, constitutive
+from funtofem import TransferScheme
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+    
+# initialize TACS for left plate
+# Create the constitutvie propertes and model
+left_kappa = 230.0
+props = constitutive.MaterialProperties(kappa=left_kappa)
+con = constitutive.PlaneStressConstitutive(props)
+heat = elements.HeatConduction2D(con)
+
+# Create the basis class
+quad_basis = elements.LinearQuadBasis()
+
+# Create the element
+element = elements.Element2D(heat, quad_basis)
+
+# Load in the mesh
+mesh = TACS.MeshLoader(comm)
+mesh.scanBDFFile('left_plate.bdf')
+
+# Set the element
+mesh.setElement(0, element)
+
+# Create the assembler object
+varsPerNode = heat.getVarsPerNode()
+l_assembler = mesh.createTACS(varsPerNode)
+
+# get structures nodes
+left_pts = l_assembler.createNodeVec()
+l_assembler.getNodes(left_pts)
+left_pts_array = left_pts.getArray()
+
+# get mapping of shared edge
+# for left plate this is x=1.0 edge
+# also get second row of node numbers for FD
+left_surface = []
+left_mapping = []
+left_f_mapping = []
+# if you change the meshes, make sure you change the values here so
+# that the mapping locates the correct nodes
+for i in range(len(left_pts_array) // 3):
+    if left_pts_array[3*i] == 1.0:
+        left_surface.extend(left_pts_array[3*i:3*i+3])
+        left_mapping.append(i)
+    if left_pts_array[3*i] < 1.0 and left_pts_array[3*i] > 0.989:
+        left_f_mapping.append(i)
+
+# Create the vectors/matrices
+l_res = l_assembler.createVec()
+l_ans = l_assembler.createVec()
+l_mat = l_assembler.createSchurMat()
+l_pc = TACS.Pc(l_mat)
+
+# Assemble the heat conduction matrix
+l_assembler.assembleJacobian(1.0, 0.0, 0.0, l_res, l_mat)
+l_pc.factor()
+l_gmres = TACS.KSM(l_mat, l_pc, 20)
+
+# Now initialize TACS for right plate in the same way
+# Create the constitutvie propertes and model
+right_kappa = 230.0
+props = constitutive.MaterialProperties(kappa=right_kappa)
+con = constitutive.PlaneStressConstitutive(props)
+heat = elements.HeatConduction2D(con)
+
+# Create the basis class
+quad_basis = elements.LinearQuadBasis()
+
+# Create the element
+element = elements.Element2D(heat, quad_basis)
+
+# Load in the mesh
+mesh = TACS.MeshLoader(comm)
+mesh.scanBDFFile('right_plate.bdf')
+
+# Set the element
+mesh.setElement(0, element)
+
+# Create the assembler object
+varsPerNode = heat.getVarsPerNode()
+r_assembler = mesh.createTACS(varsPerNode)
+
+# get structures nodes
+right_pts = r_assembler.createNodeVec()
+r_assembler.getNodes(right_pts)
+right_pts_array = right_pts.getArray()
+
+# get mapping of shared edge
+# for right plate this is x=1.0 edge
+right_surface = []
+right_mapping = []
+# if you change the meshes, make sure you change the values here so
+# that the mapping locates the correct nodes
+for i in range(len(right_pts_array) // 3):
+    if right_pts_array[3*i] == 1.0:
+        right_surface.extend(right_pts_array[3*i:3*i+3])
+        right_mapping.append(i)
+
+# Create the vectors/matrices
+r_res = r_assembler.createVec()
+r_ans = r_assembler.createVec()
+r_mat = r_assembler.createSchurMat()
+r_pc = TACS.Pc(r_mat)
+
+# Assemble the heat conduction matrix
+r_assembler.assembleJacobian(1.0, 0.0, 0.0, r_res, r_mat)
+r_pc.factor()
+r_gmres = TACS.KSM(r_mat, r_pc, 20)
+
+right_surface = np.array(right_surface)
+left_surface = np.array(left_surface)
+right_mapping = np.array(right_mapping)
+left_mapping = np.array(left_mapping)
+
+# initialize MELDThermal
+meld = TransferScheme.pyMELDThermal(comm, comm, 0, comm, 0, -1, 10, 0.5) #axis of symmetry, num nearest neighbors, beta (distance weighting parameter)
+# set left nodes as aero, right nodes as structure
+meld.setStructNodes(right_surface)
+meld.setAeroNodes(left_surface)
+meld.initialize()
+
+# assign an initial thermal BC to right edge of left plate
+# (don't make this the correct answer)
+res_arr = l_res.getArray()
+l_assembler.setBCs(l_res)
+if len(left_mapping) > 0:
+    res_arr[left_mapping] = 400.0
+
+# initialize the right plate - isothermal BC makes all temps 400.0
+# (this is not actually necessary)
+r_assembler.setBCs(r_res)
+r_gmres.solve(r_res, r_ans)
+r_assembler.setVariables(r_ans)
+
+# allocate storage vectors
+flux_holder = np.zeros(len(left_mapping))
+res_holder = np.zeros(len(right_mapping))
+ans_holder = np.zeros(len(right_mapping))
+theta_holder = np.zeros(len(left_mapping))
+
+# initialize tempDiff variable
+tempDiff = 1000.0
+ct = 0
+# loop until the sum of the absolute value of the temperature difference
+# between subsequent iterations is less than 0.01
+while (comm.allreduce(np.max(tempDiff)) > 0.01):   
+    # get the heat flux from the left plate right edge
+    # first, solve left:
+    l_gmres.solve(l_res, l_ans)
+    l_assembler.setVariables(l_ans)
+    # temps at each node:
+    ans_arr = l_ans.getArray()
+    init_left_temps = []
+    if len(left_mapping)>0:
+	init_left_temps = ans_arr[left_mapping]
+
+    # loop over points on the right edge
+    for i in range(len(left_mapping)):
+        # finite difference derivative with each element being length 0.01
+        # use f mapping to get one row in from edge for finite difference
+        grad = (ans_arr[left_mapping[i]] - ans_arr[left_f_mapping[i]])/0.01
+        # put flux in array, multiplied by 0.01 for area weighting
+        flux_holder[i] = -grad * left_kappa * 0.01
+        if i == 0 or i == len(left_mapping) - 1:
+            flux_holder[i] *= 0.5
+
+    # set flux into TACS
+    meld.transferFlux(flux_holder, res_holder)
+    
+    # transfer flux from res holder to res array based on mapping
+    r_res.zeroEntries()
+    res_array = r_res.getArray()
+    for i in range(len(right_mapping)):
+        res_array[right_mapping[i]] = res_holder[i]
+
+    # set flux into assembler
+    r_assembler.setBCs(r_res)
+    
+    # solve thermal problem
+    r_gmres.solve(r_res, r_ans)
+    r_assembler.setBCs(r_ans)
+    r_assembler.setVariables(r_ans)
+    
+    ans_array = r_ans.getArray()
+    
+    # get the temps from the left edge of the right plate
+    for i in range(len(right_mapping)):
+        ans_holder[i] = ans_array[right_mapping[i]]
+
+    # transfer surface temps to theta (size of nodes on left mapping)
+    meld.transferTemp(ans_holder, theta_holder)
+
+    res_array = l_res.getArray()    
+    # now transfer those thetas to appropriate nodes in left plate residual
+    # set the temperature to the initial temperature + 90% of the difference
+    # between the new temp and the initial
+    # the 90% damping factor can be adjusted, for this case 50% gives very fast
+    # convergence because the proper temperature of the interface is
+    # halfway between the isothermal BCs
+    for i in range(len(left_mapping)):
+        res_array[left_mapping[i]] = init_left_temps[i] + 0.9*(theta_holder[i] - init_left_temps[i])
+
+    tempDiff = comm.allreduce(sum(abs(theta_holder - init_left_temps)))
+    if comm.Get_rank()==0:
+	print('Temperature Difference = ', tempDiff)
+    	ct += 1
+
+if comm.Get_rank()==0:
+    print('Iterations = ', ct)
+
+# Set the element flag
+flag = (TACS.OUTPUT_CONNECTIVITY |
+        TACS.OUTPUT_NODES |
+        TACS.OUTPUT_DISPLACEMENTS |
+        TACS.OUTPUT_STRAINS)
+f5 = TACS.ToFH5(r_assembler, TACS.SCALAR_2D_ELEMENT, flag)
+f5.writeToFile('right_plate.f5')
+f5 = TACS.ToFH5(l_assembler, TACS.SCALAR_2D_ELEMENT, flag)
+f5.writeToFile('left_plate.f5')

--- a/examples/pyfuntofem/conduction/uniform_case/generate_left_plate_bdf.py
+++ b/examples/pyfuntofem/conduction/uniform_case/generate_left_plate_bdf.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+nx = 11
+ny = 11
+
+x = np.linspace(0, 1.0, num = nx)
+y = np.linspace(0, 1.0, num = ny)
+
+nodes = np.arange(1, nx*ny+1, dtype=np.int).reshape(nx, ny)
+
+fp = open('left_plate.bdf', 'w')
+fp.write('$ Input file for the left plate\n')
+fp.write('SOL 103\nCEND\nBEGIN BULK\n')
+
+spclist1 = []
+spclist2 = []
+
+# Write the grid points to a file
+for j in range(ny):
+    for i in range(nx):
+        # Write the nodal data
+        spc = ' '
+        coord_disp = 0
+        coord_id = 0
+        seid = 0
+        
+        fp.write('%-8s%16d%16d%16.9e%16.9e*       \n'%
+                 ('GRID*', nodes[i, j], coord_id, 
+                  x[i], y[j]))
+        fp.write('*       %16.9e%16d%16s%16d        \n'%
+                 (0.0, coord_disp, spc, seid))
+
+        if x[i] == 0.0:
+            spclist1.append(nodes[i,j])
+
+        if x[i] == 1.0:
+            spclist2.append(nodes[i,j])
+
+# Output first order quad elements
+
+elem = 1
+part_id = 1
+for j in range(0, nodes.shape[1]-1, 1):
+    for i in range(0, nodes.shape[0]-1, 1):
+        # Write the connectivity data
+        # CQUAD9 elem id n1 n2 n3 n4 n5 n6
+        #        n7   n8 n9
+        fp.write('%-8s%8d%8d%8d%8d%8d%8d\n'%
+                 ('CQUAD4', elem, part_id, 
+                  nodes[i,   j],   nodes[i+1, j], 
+                  nodes[i+1, j+1], nodes[i,   j+1]))
+
+        elem += 1
+
+for node in spclist1:
+    spc = '123456'
+    fp.write('%-8s%8d%8d%8s%8.6f\n'%
+             ('SPC', 1, node, spc, 300.0))
+
+for node in spclist2:
+    spc = '123456'
+    fp.write('%-8s%8d%8d%8s%8.6f\n'%
+             ('SPC', 1, node, spc, 400.0))
+
+fp.write('END BULK')
+fp.close()

--- a/examples/pyfuntofem/conduction/uniform_case/generate_rect_plate_bdf.py
+++ b/examples/pyfuntofem/conduction/uniform_case/generate_rect_plate_bdf.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+nx = 21
+ny = 11
+
+x = np.linspace(0, 2.0, num = nx)
+y = np.linspace(0, 1.0, num = ny)
+
+nodes = np.arange(1, nx*ny+1, dtype=np.int).reshape(nx, ny)
+
+fp = open('rect_plate.bdf', 'w')
+fp.write('$ Input file for a rectangular plate\n')
+fp.write('SOL 103\nCEND\nBEGIN BULK\n')
+
+spclist1 = []
+spclist2 = []
+
+# Write the grid points to a file
+for j in range(ny):
+    for i in range(nx):
+        # Write the nodal data
+        spc = ' '
+        coord_disp = 0
+        coord_id = 0
+        seid = 0
+        
+        fp.write('%-8s%16d%16d%16.9e%16.9e*       \n'%
+                 ('GRID*', nodes[i, j], coord_id, 
+                  x[i], y[j]))
+        fp.write('*       %16.9e%16d%16s%16d        \n'%
+                 (0.0, coord_disp, spc, seid))
+
+        if x[i] == 0.0:
+            spclist1.append(nodes[i,j])
+
+        if x[i] == 2.0:
+            spclist2.append(nodes[i,j])
+
+# Output first order quad elements
+
+elem = 1
+part_id = 1
+for j in range(0, nodes.shape[1]-1, 1):
+    for i in range(0, nodes.shape[0]-1, 1):
+        # Write the connectivity data
+        # CQUAD9 elem id n1 n2 n3 n4 n5 n6
+        #        n7   n8 n9
+        fp.write('%-8s%8d%8d%8d%8d%8d%8d\n'%
+                 ('CQUAD4', elem, part_id, 
+                  nodes[i,   j],   nodes[i+1, j], 
+                  nodes[i+1, j+1], nodes[i,   j+1]))
+
+        elem += 1
+
+for node in spclist1:
+    spc = '123456'
+    fp.write('%-8s%8d%8d%8s%8.6f\n'%
+             ('SPC', 1, node, spc, 300.0))
+
+for node in spclist2:
+    spc = '123456'
+    fp.write('%-8s%8d%8d%8s%8.6f\n'%
+             ('SPC', 1, node, spc, 400.0))
+
+fp.write('END BULK')
+fp.close()

--- a/examples/pyfuntofem/conduction/uniform_case/generate_right_plate_bdf.py
+++ b/examples/pyfuntofem/conduction/uniform_case/generate_right_plate_bdf.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+nx = 11
+ny = 11
+
+x = np.linspace(1.0, 2.0, num = nx)
+y = np.linspace(0, 1.0, num = ny)
+
+nodes = np.arange(1, nx*ny+1, dtype=np.int).reshape(nx, ny)
+
+fp = open('right_plate.bdf', 'w')
+fp.write('$ Input file for the right plate\n')
+fp.write('SOL 103\nCEND\nBEGIN BULK\n')
+
+spclist1 = []
+spclist2 = []
+
+# Write the grid points to a file
+for j in range(ny):
+    for i in range(nx):
+        # Write the nodal data
+        spc = ' '
+        coord_disp = 0
+        coord_id = 0
+        seid = 0
+        
+        fp.write('%-8s%16d%16d%16.9e%16.9e*       \n'%
+                 ('GRID*', nodes[i, j], coord_id, 
+                  x[i], y[j]))
+        fp.write('*       %16.9e%16d%16s%16d        \n'%
+                 (0.0, coord_disp, spc, seid))
+
+        #if x[i] == 0.0:
+        #    spclist1.append(nodes[i,j])
+
+        if x[i] == 2.0:
+            spclist2.append(nodes[i,j])
+
+# Output first order quad elements
+
+elem = 1
+part_id = 1
+for j in range(0, nodes.shape[1]-1, 1):
+    for i in range(0, nodes.shape[0]-1, 1):
+        # Write the connectivity data
+        # CQUAD9 elem id n1 n2 n3 n4 n5 n6
+        #        n7   n8 n9
+        fp.write('%-8s%8d%8d%8d%8d%8d%8d\n'%
+                 ('CQUAD4', elem, part_id, 
+                  nodes[i,   j],   nodes[i+1, j], 
+                  nodes[i+1, j+1], nodes[i,   j+1]))
+
+        elem += 1
+
+#for node in spclist1:
+#    spc = '123456'
+#    fp.write('%-8s%8d%8d%8s%8.6f\n'%
+#             ('SPC', 1, node, spc, 300.0))
+
+for node in spclist2:
+    spc = '123456'
+    fp.write('%-8s%8d%8d%8s%8.6f\n'%
+             ('SPC', 1, node, spc, 400.0))
+
+fp.write('END BULK')
+fp.close()

--- a/examples/pyfuntofem/conduction/uniform_case/tacs_verification.py
+++ b/examples/pyfuntofem/conduction/uniform_case/tacs_verification.py
@@ -1,0 +1,54 @@
+from __future__ import print_function
+from mpi4py import MPI
+import numpy as np
+import matplotlib.pyplot as plt
+import sys
+from tacs import TACS, elements, constitutive
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+    
+# initialize TACS for left plate
+# Create the constitutvie propertes and model
+props = constitutive.MaterialProperties()
+con = constitutive.PlaneStressConstitutive(props)
+heat = elements.HeatConduction2D(con)
+
+# Create the basis class
+quad_basis = elements.LinearQuadBasis()
+
+# Create the element
+element = elements.Element2D(heat, quad_basis)
+
+# Load in the mesh
+mesh = TACS.MeshLoader(comm)
+mesh.scanBDFFile('rect_plate.bdf')
+
+# Set the element
+mesh.setElement(0, element)
+
+# Create the assembler object
+varsPerNode = heat.getVarsPerNode()
+assembler = mesh.createTACS(varsPerNode)
+
+res = assembler.createVec()
+ans = assembler.createVec()
+mat = assembler.createSchurMat()
+pc = TACS.Pc(mat)
+
+# Assemble the heat conduction matrix
+assembler.assembleJacobian(1.0, 0.0, 0.0, res, mat)
+pc.factor()
+gmres = TACS.KSM(mat, pc, 20)
+
+assembler.setBCs(res)
+gmres.solve(res, ans)
+assembler.setVariables(ans)
+
+# Set the element flag
+flag = (TACS.OUTPUT_CONNECTIVITY |
+        TACS.OUTPUT_NODES |
+        TACS.OUTPUT_DISPLACEMENTS |
+        TACS.OUTPUT_STRAINS)
+f5 = TACS.ToFH5(assembler, TACS.SCALAR_2D_ELEMENT, flag)
+f5.writeToFile('verification.f5')

--- a/examples/pyfuntofem/conduction/uniform_case/two_plate_conduction.py
+++ b/examples/pyfuntofem/conduction/uniform_case/two_plate_conduction.py
@@ -1,0 +1,230 @@
+from __future__ import print_function
+from mpi4py import MPI
+import numpy as np
+import matplotlib.pyplot as plt
+import sys
+from tacs import TACS, elements, constitutive
+from funtofem import TransferScheme
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+    
+# initialize TACS for left plate
+# Create the constitutvie propertes and model
+left_kappa = 230.0
+props = constitutive.MaterialProperties(kappa=left_kappa)
+con = constitutive.PlaneStressConstitutive(props)
+heat = elements.HeatConduction2D(con)
+
+# Create the basis class
+quad_basis = elements.LinearQuadBasis()
+
+# Create the element
+element = elements.Element2D(heat, quad_basis)
+
+# Load in the mesh
+mesh = TACS.MeshLoader(comm)
+mesh.scanBDFFile('left_plate.bdf')
+
+# Set the element
+mesh.setElement(0, element)
+
+# Create the assembler object
+varsPerNode = heat.getVarsPerNode()
+l_assembler = mesh.createTACS(varsPerNode)
+
+# get structures nodes
+left_pts = l_assembler.createNodeVec()
+l_assembler.getNodes(left_pts)
+left_pts_array = left_pts.getArray()
+
+# get mapping of shared edge
+# for left plate this is x=1.0 edge
+# also get second column of node numbers (x=0.9 for this case)
+# (used later to get the gradient in x direction)
+left_surface = []
+left_mapping = []
+left_f_mapping = []
+for i in range(len(left_pts_array) // 3):
+    if left_pts_array[3*i]  > .99:
+        left_surface.extend(left_pts_array[3*i:3*i+3])
+        left_mapping.append(i)
+    if left_pts_array[3*i]  > 0.89 and left_pts_array[3*i]  < 0.91:
+        left_f_mapping.append(i)
+
+# Create the vectors/matrices
+l_res = l_assembler.createVec()
+l_ans = l_assembler.createVec()
+l_mat = l_assembler.createSchurMat()
+l_pc = TACS.Pc(l_mat)
+
+# Assemble the heat conduction matrix
+l_assembler.assembleJacobian(1.0, 0.0, 0.0, l_res, l_mat)
+l_pc.factor()
+l_gmres = TACS.KSM(l_mat, l_pc, 20)
+
+# Now initialize TACS for right plate in the same way
+# Create the constitutvie propertes and model
+#right_kappa = 460.0
+right_kappa = 230.0
+props = constitutive.MaterialProperties(kappa=right_kappa)
+con = constitutive.PlaneStressConstitutive(props)
+heat = elements.HeatConduction2D(con)
+
+# Create the basis class
+quad_basis = elements.LinearQuadBasis()
+
+# Create the element
+element = elements.Element2D(heat, quad_basis)
+
+# Load in the mesh
+mesh = TACS.MeshLoader(comm)
+mesh.scanBDFFile('right_plate.bdf')
+
+# Set the element
+mesh.setElement(0, element)
+
+# Create the assembler object
+varsPerNode = heat.getVarsPerNode()
+r_assembler = mesh.createTACS(varsPerNode)
+
+# get structures nodes
+right_pts = r_assembler.createNodeVec()
+r_assembler.getNodes(right_pts)
+right_pts_array = right_pts.getArray()
+
+# get mapping of shared edge
+# for right plate this is x=1.0 edge (since right plate
+# goes from x=1.0 to x=2.0 and the BC is at 2.0)
+right_surface = []
+right_mapping = []
+for i in range(len(right_pts_array) // 3):
+    if right_pts_array[3*i]  < 1.01:
+        right_surface.extend(right_pts_array[3*i:3*i+3])
+        right_mapping.append(i)
+
+# Create the vectors/matrices
+r_res = r_assembler.createVec()
+r_ans = r_assembler.createVec()
+r_mat = r_assembler.createSchurMat()
+r_pc = TACS.Pc(r_mat)
+
+# Assemble the heat conduction matrix
+r_assembler.assembleJacobian(1.0, 0.0, 0.0, r_res, r_mat)
+r_pc.factor()
+r_gmres = TACS.KSM(r_mat, r_pc, 20)
+
+right_surface = np.array(right_surface)
+left_surface = np.array(left_surface)
+right_mapping = np.array(right_mapping)
+left_mapping = np.array(left_mapping)
+
+# initialize MELDThermal
+# note that for this case with a very small number of nodes in each set,
+# increasing the number of nearest neighbors drastically degrades the accuracy
+# because it smears the flux over the interface.
+# the main issue with this is that the flux at the top and bottom nodes in the mapping
+# are half as much as the flux at he rest of the nodes
+# also note that when setting the num_nearest to 1 (i.e. 1 to 1 transfer of quantites
+# between selected nodes) we recover the exact solution at the boundary
+meld = TransferScheme.pyMELDThermal(comm, comm, 0, comm, 0, -1, 3, 0.5) #axis of symmetry, num nearest, beta
+# set left nodes as aero, right nodes as structure
+# the nodes you want to send heat flux to become structure
+# the nodes you want to send temperatures to become aero
+meld.setStructNodes(right_surface)
+meld.setAeroNodes(left_surface)
+meld.initialize()
+
+# assign an initial thermal BC to right edge of left plate
+res_arr = l_res.getArray()
+l_assembler.setBCs(l_res)
+if len(left_mapping)>0:
+    res_arr[left_mapping] = 380.0
+
+r_assembler.setBCs(r_res)
+r_gmres.solve(r_res, r_ans)
+r_assembler.setVariables(r_ans)
+
+# allocate storage vectors
+flux_holder = np.zeros(len(left_mapping))
+res_holder = np.zeros(len(right_mapping))
+ans_holder = np.zeros(len(right_mapping))
+theta_holder = np.zeros(len(left_mapping))
+
+tempDiff = 1000.0
+ct = 0
+# iterate until sum of absolute values of temperature differences between subsequent solutions gets less than 0.01
+while (tempDiff > .01):
+    
+    # get the heat flux from the left plate right edge
+    # first, solve left:
+    l_gmres.solve(l_res, l_ans)
+    l_assembler.setVariables(l_ans)
+    # temps at each node:
+    ans_arr = l_ans.getArray()
+    init_left_temps = []
+    if len(left_mapping)>0:
+        init_left_temps = ans_arr[left_mapping]
+
+    # loop over points on the right edge
+    for i in range(len(left_mapping)):
+        # finite difference derivative
+        # Division by 0.1 is for the distance between nodes in x direction
+        grad = (ans_arr[left_mapping[i]] - ans_arr[left_f_mapping[i]])/0.1
+        # put flux in array, multiplied by 0.1 for area weighting
+        flux_holder[i] = -grad * left_kappa * 0.1
+        if i == 0 or i == len(left_mapping) - 1:
+            flux_holder[i] *= 0.5
+
+    # set flux into TACS
+    meld.transferFlux(flux_holder, res_holder)
+    # transfer flux from res holder to res array based on mapping
+    r_res.zeroEntries()
+    res_array = r_res.getArray()
+    for i in range(len(right_mapping)):
+        res_array[right_mapping[i]] = res_holder[i]
+
+    # set flux into assembler
+    r_assembler.setBCs(r_res)
+    
+    # solve thermal problem
+    r_gmres.solve(r_res, r_ans)
+    r_assembler.setBCs(r_ans)
+    r_assembler.setVariables(r_ans)
+    
+    ans_array = r_ans.getArray()
+    
+    # get the temps from the left edge of the right plate
+    for i in range(len(right_mapping)):
+        ans_holder[i] = ans_array[right_mapping[i]]
+
+    # transfer surface temps to theta (size of nodes on left mapping)
+    meld.transferTemp(ans_holder, theta_holder)
+
+    res_array = l_res.getArray()    
+    # now transfer those thetas to appropriate nodes in left plate residual
+    # set the temperature to the initial temperature + 90% of the difference
+    # between the new temp and the initial
+
+    # note that the factor of 0.9 controls the speed of convergence
+    # clearly at 0.5 it goes directly to the solution
+    for i in range(len(left_mapping)):
+        res_array[left_mapping[i]] = init_left_temps[i] + 0.75*(theta_holder[i] - init_left_temps[i])
+
+    tempDiff = comm.allreduce(sum(abs(theta_holder - init_left_temps)))
+    if comm.Get_rank()==0:
+	print('Temperature Difference = ', tempDiff)
+	ct += 1
+
+if comm.Get_rank()==0:
+    print('Iterations = ',ct)
+
+# Set the element flag
+flag = (TACS.OUTPUT_CONNECTIVITY |
+        TACS.OUTPUT_NODES |
+        TACS.OUTPUT_DISPLACEMENTS |
+        TACS.OUTPUT_STRAINS)
+f5 = TACS.ToFH5(r_assembler, TACS.SCALAR_2D_ELEMENT, flag)
+f5.writeToFile('right_plate.f5')
+f5 = TACS.ToFH5(l_assembler, TACS.SCALAR_2D_ELEMENT, flag)
+f5.writeToFile('left_plate.f5')

--- a/funtofem/TransferScheme.pxd
+++ b/funtofem/TransferScheme.pxd
@@ -80,6 +80,19 @@ cdef extern from "MELD.h":
          MPI_Comm aero, int aero_root,
          int symmetry, int num_nearest, F2FScalar beta)
 
+cdef extern from "MELDThermal.h":
+  cppclass MELDThermal(TransferScheme):
+    # Constructor
+    MELDThermal(MPI_Comm all,
+                MPI_Comm structure, int struct_root,
+                MPI_Comm aero, int aero_root,
+                int symmetry, int num_nearest, F2FScalar beta)
+
+    void transferTemp(const F2FScalar *struct_temp,
+                               F2FScalar *aero_temp)
+    void transferFlux(const F2FScalar *aero_flux,
+                               F2FScalar *struct_flux)
+
 cdef extern from "LinearizedMELD.h":
   cppclass LinearizedMELD(MELD):
     # Constructor

--- a/funtofem/TransferScheme.pxd
+++ b/funtofem/TransferScheme.pxd
@@ -93,6 +93,27 @@ cdef extern from "MELDThermal.h":
     void transferFlux(const F2FScalar *aero_flux,
                                F2FScalar *struct_flux)
 
+    # Action of transpose Jacobians needed for solving adjoint system
+    void applydTdtS(const F2FScalar *vecs, F2FScalar *prods)
+    void applydTdtSTrans(const F2FScalar *vecs, F2FScalar *prods)
+    void applydQdqA(const F2FScalar *vecs, F2FScalar *prods)
+    void applydQdqATrans(const F2FScalar *vecs, F2FScalar *prods)
+
+    # Routines to test necessary functionality of transfer scheme
+    void testFluxTransfer(const F2FScalar *struct_temps,
+                          const F2FScalar *aero_flux,
+                          const F2FScalar *pert, 
+                          const F2FScalar h)
+    void testTempJacVecProducts(const F2FScalar *struct_temps, 
+                                const F2FScalar *test_vec_a, 
+                                const F2FScalar *test_vec_s,
+                                const F2FScalar h)
+    void testFluxJacVecProducts(const F2FScalar *struct_temps, 
+                                const F2FScalar *aero_flux,
+                                const F2FScalar *test_vec_s1, 
+                                const F2FScalar *test_vec_s2,
+                                const F2FScalar h)
+
 cdef extern from "LinearizedMELD.h":
   cppclass LinearizedMELD(MELD):
     # Constructor

--- a/funtofem/TransferScheme.pyx
+++ b/funtofem/TransferScheme.pyx
@@ -713,6 +713,181 @@ cdef class pyMELDThermal(pyTransferScheme):
         cdef MELDThermal *mt = <MELDThermal*> self.ptr
         mt.transferFlux(<F2FScalar*>aero_flux.data, <F2FScalar*>struct_flux.data)
         return
+    
+    def applydTdtS(self, np.ndarray[F2FScalar, ndim=1, mode='c'] v,
+                   np.ndarray[F2FScalar, ndim=1, mode='c'] p):
+        """
+        Apply the action of the Jacobian containing the derivatives of the
+        displacement transfer residuals with respect to the structural
+        displacements to an input vector and stores the products in empty
+        input array
+
+        Parameters
+        ----------
+        v: ndarray
+            One-dimensional array of size of structural displacements
+        p: ndarray
+            One-dimensional empty array of size of aerodynamic displacements
+
+        """
+        cdef MELDThermal *mt = <MELDThermal*> self.ptr
+        mt.applydTdtS(<F2FScalar*>v.data, <F2FScalar*>p.data)
+        return
+
+    def applydTdtSTrans(self, np.ndarray[F2FScalar, ndim=1, mode='c'] v,
+                        np.ndarray[F2FScalar, ndim=1, mode='c'] p):
+        """
+        Apply the action of the transpose of the Jacobian containing the
+        derivatives of the displacement transfer residuals with respect to the
+        structural displacements to an input vector and store the products in
+        empty input array
+
+        Parameters
+        ----------
+        v: ndarray
+            One-dimensional array of size of aerodynamic displacements
+        p: ndarray
+            One-dimensional empty array of size of structural displacements
+
+        """
+        cdef MELDThermal *mt = <MELDThermal*> self.ptr
+        mt.applydTdtSTrans(<F2FScalar*>v.data, <F2FScalar*>p.data)
+        return
+
+    def applydQdqA(self, np.ndarray[F2FScalar, ndim=1, mode='c'] v,
+                   np.ndarray[F2FScalar, ndim=1, mode='c'] p):
+        """
+        Apply the action of the Jacobian containing the derivatives of the load
+        transfer residuals with respect to the structural displacements to an
+        input vector and store the products in empty input array
+
+        Parameters
+        ----------
+        v: ndarray
+            One-dimensional array of size of structural displacements
+        p: ndarray
+            One-dimensional empty array of size of structural loads
+
+        """
+        cdef MELDThermal *mt = <MELDThermal*> self.ptr
+        mt.applydQdqA(<F2FScalar*>v.data, <F2FScalar*>p.data)
+        return
+
+    def applydQdqATrans(self, np.ndarray[F2FScalar, ndim=1, mode='c'] v,
+                        np.ndarray[F2FScalar, ndim=1, mode='c'] p):
+        """
+        Apply the action of the transpose of the Jacobian containing the
+        derivatives of the load transfer residuals with respect to the
+        structural displacements to an input vector and store the products in
+        empty input array
+
+        Parameters
+        ----------
+        v: ndarray
+            One-dimensional array of size of structural loads
+        p: ndarray
+            One-dimensional empty array of size of structural displacements
+
+        """
+        cdef MELDThermal *mt = <MELDThermal*> self.ptr
+        mt.applydQdqATrans(<F2FScalar*>v.data, <F2FScalar*>p.data)
+        return
+
+
+    def testFluxTransfer(self, 
+            np.ndarray[F2FScalar, ndim=1, mode='c'] struct_temps,
+            np.ndarray[F2FScalar, ndim=1, mode='c'] aero_flux,
+            np.ndarray[F2FScalar, ndim=1, mode='c'] test_vec_s,
+            F2FScalar h):
+        """
+        Test the output of :meth:`transferLoads` by comparison with results from
+        finite difference approximation or complex step approximation
+
+        Parameters
+        ----------
+        struct_disps: ndarray
+            One-dimensional array of structural displacements
+        aero_loads: ndarray
+            One-dimensional array of aerodynamic loads
+        test_vec_s: ndarray
+            One-dimensional array of perturbations of size of structural
+            displacements
+        h: float
+            Step size (for finite difference or complex step)
+
+        """
+        cdef MELDThermal *mt = <MELDThermal*> self.ptr
+        mt.testFluxTransfer(<F2FScalar*>struct_temps.data,
+                                  <F2FScalar*>aero_flux.data,
+                                  <F2FScalar*>test_vec_s.data, h)
+
+        return
+
+    def testTempJacVecProducts(self, 
+            np.ndarray[F2FScalar, ndim=1, mode='c'] struct_temps,
+            np.ndarray[F2FScalar, ndim=1, mode='c'] test_vec_a,
+            np.ndarray[F2FScalar, ndim=1, mode='c'] test_vec_s,
+            F2FScalar h):
+        """
+        Test output of :meth:`applydDduS` and :meth:`applydDduSTrans` by
+        comparison with results from finite difference approximation or
+        complex step approximation
+
+        Parameters
+        ----------
+        struct_disps: ndarray
+            One-dimensional array of structural displacements
+        test_vec_a: ndarray
+            One-dimensional array of perturbations of size of displacement
+            transfer residuals
+        test_vec_s: ndarray
+            One-dimensional array of perturbations of size of structural
+            displacements
+        h: float
+            Step size (for finite difference or complex step)
+
+        """
+        cdef MELDThermal *mt = <MELDThermal*> self.ptr
+        mt.testTempJacVecProducts(<F2FScalar*>struct_temps.data,
+                                        <F2FScalar*>test_vec_a.data,
+                                        <F2FScalar*>test_vec_s.data, h)
+
+        return
+
+    def testFluxJacVecProducts(self, 
+            np.ndarray[F2FScalar, ndim=1, mode='c'] struct_temps,
+            np.ndarray[F2FScalar, ndim=1, mode='c'] aero_flux,
+            np.ndarray[F2FScalar, ndim=1, mode='c'] test_vec_s1,
+            np.ndarray[F2FScalar, ndim=1, mode='c'] test_vec_s2,
+            F2FScalar h):
+        """
+        Test output of :meth:`applydLduS` and :meth:`applydLduSTrans` by
+        comparison with results from finite difference approximation or
+        complex step approximation
+
+        Parameters
+        ----------
+        struct_disps: ndarray
+            One-dimensional array of structural displacements
+        aero_loads: ndarray
+            One-dimensional array of aerodynamic loads
+        test_vec_s1: ndarray
+            One-dimensional array of perturbations of size of load transfer
+            residuals
+        test_vec_s2: ndarray
+            One-dimensional array of perturbations of size of structural
+            displacements
+        h: float
+            Step size (for finite difference or complex step)
+
+        """
+        cdef MELDThermal *mt = <MELDThermal*> self.ptr
+        mt.testFluxJacVecProducts(<F2FScalar*>struct_temps.data,
+                                        <F2FScalar*>aero_flux.data,
+                                        <F2FScalar*>test_vec_s1.data,
+                                        <F2FScalar*>test_vec_s2.data, h)
+
+        return
 
 
 # Wrap the MELD class

--- a/include/MELDThermal.h
+++ b/include/MELDThermal.h
@@ -48,6 +48,28 @@ class MELDThermal : public TransferScheme {
   void transferFlux(const F2FScalar *aero_flux,
                     F2FScalar *struct_flux);
 
+  // Action of transpose Jacobians needed for solving adjoint system
+  void applydTdtS(const F2FScalar *vecs, F2FScalar *prods);
+  void applydTdtSTrans(const F2FScalar *vecs, F2FScalar *prods);
+  void applydQdqA(const F2FScalar *vecs, F2FScalar *prods);
+  void applydQdqATrans(const F2FScalar *vecs, F2FScalar *prods);
+
+  //Test Functions
+  void testFluxTransfer(const F2FScalar *struct_temps,
+                                      const F2FScalar *aero_flux,
+                                      const F2FScalar *pert, 
+                                      const F2FScalar h);
+  void testTempJacVecProducts(const F2FScalar *struct_temps, 
+                                            const F2FScalar *test_vec_a, 
+                                            const F2FScalar *test_vec_s,
+                                            const F2FScalar h);
+  void testFluxJacVecProducts(const F2FScalar *struct_temps, 
+                                            const F2FScalar *aero_flux,
+                                            const F2FScalar *test_vec_s1, 
+                                            const F2FScalar *test_vec_s2,
+                                            const F2FScalar h);
+
+  // Inherited Displacement and Load Transfer functions (NOT implemented for Thermal MELD scheme)
   void transferDisps(const F2FScalar*, F2FScalar*){}
   void transferLoads(const F2FScalar*, F2FScalar*){}
   void applydDduS(const F2FScalar*, F2FScalar*){}


### PR DESCRIPTION
It looks like we didn't update the python wrapper when we pushed the MELDThermal changes to the public repo, so I updated those files and added the conduction examples.